### PR TITLE
Tiny readability fix

### DIFF
--- a/en/mongodb.markdown
+++ b/en/mongodb.markdown
@@ -99,7 +99,7 @@ First we'll use the global `use` method to switch databases, go ahead and enter 
 
 	db.unicorns.insert({name: 'Aurora', gender: 'f', weight: 450})
 
-The above line is executing `insert` against the `unicorns` collection, passing it a single argument. Internally MongoDB uses a binary serialized JSON format. Externally, this means that we use JSON a lot, as is the case with our parameters. If we execute `db.getCollectionNames()` now, we'll actually see two collections: `unicorns` and `system.indexes`. `system.indexes` is created once per database and contains the information on our database's index.
+The above line is executing `insert` against the `unicorns` collection, passing it a single argument. Internally MongoDB uses a binary serialized JSON format. Externally, this means that we use JSON a lot, as is the case with our parameters. If we execute `db.getCollectionNames()` now, we'll actually see two collections: `unicorns` and `system.indexes`. The collection `system.indexes` is created once per database and contains the information on our database's index.
 
 You can now use the `find` command against `unicorns` to return a list of documents:
 


### PR DESCRIPTION
The separation between the two sentences ending and starting with emphasized words
... `system.indexes`. `system.indexes` ...
could you Normal case words in between :)
