### PR TITLE
Fix karlseguin/the-little-mongodb-book#33: quotes

### DIFF
--- a/common/pdf-template.tex
+++ b/common/pdf-template.tex
@@ -57,6 +57,7 @@
 
 
 % Listings
+\usepackage{upquote}
 
 \usepackage{listings}
 


### PR DESCRIPTION
Added `upquote` package to Latex template. Now, copying and pasting from the
pdf into `mongo` works when quotes are present.
