### PR TITLE
remove ligatures from quotes in markdown

### DIFF
--- a/common/pdf-template.tex
+++ b/common/pdf-template.tex
@@ -5,11 +5,11 @@
 
 %% Typography
 \usepackage[no-math]{fontspec}
-\defaultfontfeatures{Mapping = tex-text, Scale = MatchLowercase}
+\defaultfontfeatures{Scale = MatchLowercase}
 
 %% Fonts
-\setmainfont{Verdana}
-\setsansfont{Verdana}
+\setmainfont[Ligatures=TeX]{Verdana}
+\setsansfont[Ligatures=TeX]{Verdana}
 \setmonofont{Consolas}
 
 %% Set Sans font in headings


### PR DESCRIPTION
this will render the quotes as straight quotes instead of decorated quotes (more traditional for programming fonts)
